### PR TITLE
Remove old create script

### DIFF
--- a/create_vm.sh
+++ b/create_vm.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cp -r template-vm $1
-sed -i "s/template-vm/${1}/g" $1/Vagrantfile


### PR DESCRIPTION
# Description

Simple change to remove the old ```create_vm.sh``` because that function was added to the make file.

Fixes # (issue)

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

### All Submissions:

- [X] Have you run the `validate.sh` command and was it successful?