### PR TITLE
Update to remove checks for VM name, but it was global

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,6 @@ installed := $(vagrant box list)
 name = 
 box = 
 
-check-variables:
-ifndef name
-  $(error name is undefined)
-endif
-ifndef box
-  $(error box is undefined)
-endif
-
 install:
 	@for box in $(targets); do \
 		printf "\nInstalling $$box\n" && vagrant box add $$box --provider=$(hypervisor); done


### PR DESCRIPTION
# Description

This update fixes a bug that was intended to create checks for the VM part of the script, but was global so I removed it so that the script works, and will research to see how to make them zoned.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

### All Submissions:

- [X] Have you run the `validate.sh` command and was it successful?