### PR TITLE
Fixed syntax error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ vm:
 	test -n "${box}" ## Please specify your box: box=somebox
 	@cp -R ./template-vm ./$(name)
 	@sed -i 's/template-vm/$(name)/g' ./$(name)/Vagrantfile
-	@sed -i 's/generic\/$(name)/generic\/${box}/g' ./$(name)/Vagrantfile
+	@sed -i 's/generic\/$(name)/generic\/$(box)/g' ./$(name)/Vagrantfile


### PR DESCRIPTION
# Description

Error resolution in Makefile changing from '{' to '(' .. 

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

### All Submissions:

- [X] Have you run the `validate.sh` command and was it successful?