### PR TITLE
Update to ubuntu 20.04

### DIFF
--- a/ubuntu-20/Vagrantfile
+++ b/ubuntu-20/Vagrantfile
@@ -7,7 +7,7 @@ MACHINE_NAME = 'ubuntu-20'.freeze
 CONFIG_ENGINE = 'ansible'.freeze
 
 # Ansible global controls
-ANSIBLE_PLAYBOOK = 'ansible-fedora-base'.freeze
+ANSIBLE_PLAYBOOK = 'ansible-linux-base'.freeze
 ANSIBLE_ROLE = 'server'.freeze
 ANSIBLE_SETUP_FILE = 'setup_server.yml'.freeze
 


### PR DESCRIPTION
# Description

This update fixes the Ubuntu 20.04 image to use the Linux base and not the Fedora ansible runlist.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

### All Submissions:

- [X] Have you run the `validate.sh` command and was it successful?