### PR TITLE
Add 'make setup' to install the right provider for your host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ VM_ROOT ?= .machines
 
 .DEFAULT_GOAL := help
 
-.PHONY: help doctor install new up halt destroy ssh provision status list clean
+.PHONY: help doctor setup install new up halt destroy ssh provision status list clean
 
 help:
 	@echo "Vagrant machines — works the same on Mac (qemu) and Linux (libvirt/virtualbox)."
 	@echo
 	@echo "Setup:"
 	@echo "  make doctor                Check prereqs for your platform"
+	@echo "  make setup                 Install Vagrant provider + plugin for your platform"
 	@echo "  make install               Install all default boxes for your provider"
 	@echo
 	@echo "Create / control machines:"
@@ -28,6 +29,9 @@ help:
 
 doctor:
 	@bin/doctor
+
+setup:
+	@bin/install-provider
 
 install:
 	@bin/install-boxes

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ the right Ansible playbook for the OS family.
 
 ```sh
 make doctor                         # check prereqs for your platform
+make setup                          # install the right provider + plugin for your host
 make install                        # install default boxes for your provider
 
 make new                            # interactive: pick OS, name, role

--- a/bin/doctor
+++ b/bin/doctor
@@ -64,6 +64,7 @@ echo
 if [ $status -eq 0 ]; then
   info "All checks passed."
 else
-  info "Some checks failed. See hints above."
+  info "Some checks failed. Run 'make setup' to install the provider for your platform,"
+  info "or follow the hints above."
   exit 1
 fi

--- a/bin/install-provider
+++ b/bin/install-provider
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Install the Vagrant provider (and its plugin) appropriate for this host.
+#   - macOS Apple Silicon  -> qemu (brew) + vagrant-qemu
+#   - macOS Intel          -> virtualbox (brew cask)
+#   - Linux Debian/Ubuntu  -> libvirt or virtualbox (apt) + vagrant-libvirt
+#   - Linux Fedora/RHEL    -> libvirt (dnf) + vagrant-libvirt
+#
+# Override provider:        PROVIDER=libvirt bin/install-provider
+# Skip confirmation prompt: YES=1 bin/install-provider
+set -euo pipefail
+. "$(dirname "$0")/_lib.sh"
+
+provider="${PROVIDER:-$(default_provider)}"
+yes="${YES:-0}"
+
+confirm() {
+  [ "$yes" = "1" ] && return 0
+  printf '%s [y/N] ' "$1" >&2
+  read -r ans || return 1
+  case "$ans" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
+}
+
+run() {
+  printf '+ %s\n' "$*" >&2
+  "$@"
+}
+
+# Detect Linux package manager (lazy — only invoked on linux paths).
+linux_pkg_mgr() {
+  if   command -v apt-get >/dev/null 2>&1; then printf 'apt\n'
+  elif command -v dnf     >/dev/null 2>&1; then printf 'dnf\n'
+  elif command -v yum     >/dev/null 2>&1; then printf 'yum\n'
+  else die "no supported package manager found (apt/dnf/yum)"
+  fi
+}
+
+ensure_brew() {
+  command -v brew >/dev/null 2>&1 || die "Homebrew is required (https://brew.sh)"
+}
+
+install_macos_qemu() {
+  ensure_brew
+  if command -v qemu-system-aarch64 >/dev/null 2>&1; then
+    info "qemu already installed."
+  else
+    confirm "Install qemu via 'brew install qemu'?" || die "aborted"
+    run brew install qemu
+  fi
+  install_plugin vagrant-qemu
+}
+
+install_macos_virtualbox() {
+  ensure_brew
+  if command -v VBoxManage >/dev/null 2>&1; then
+    info "VirtualBox already installed."
+  else
+    confirm "Install VirtualBox via 'brew install --cask virtualbox' (will prompt for admin password)?" || die "aborted"
+    run brew install --cask virtualbox
+  fi
+}
+
+install_linux_virtualbox() {
+  case "$(linux_pkg_mgr)" in
+    apt) confirm "Install VirtualBox via 'sudo apt-get install -y virtualbox'?" || die "aborted"
+         run sudo apt-get update
+         run sudo apt-get install -y virtualbox ;;
+    dnf) confirm "Install VirtualBox via 'sudo dnf install -y VirtualBox'?" || die "aborted"
+         run sudo dnf install -y VirtualBox ;;
+    yum) confirm "Install VirtualBox via 'sudo yum install -y VirtualBox'?" || die "aborted"
+         run sudo yum install -y VirtualBox ;;
+  esac
+}
+
+install_linux_libvirt() {
+  case "$(linux_pkg_mgr)" in
+    apt) confirm "Install libvirt + qemu-kvm via apt?" || die "aborted"
+         run sudo apt-get update
+         run sudo apt-get install -y libvirt-daemon-system libvirt-clients libvirt-dev qemu-kvm bridge-utils virtinst ;;
+    dnf) confirm "Install libvirt + qemu-kvm via dnf?" || die "aborted"
+         run sudo dnf install -y libvirt qemu-kvm libvirt-devel bridge-utils virt-install ;;
+    yum) confirm "Install libvirt + qemu-kvm via yum?" || die "aborted"
+         run sudo yum install -y libvirt qemu-kvm libvirt-devel bridge-utils virt-install ;;
+  esac
+  if ! systemctl is-active --quiet libvirtd 2>/dev/null; then
+    confirm "Enable and start libvirtd?" && run sudo systemctl enable --now libvirtd || true
+  fi
+  if ! id -nG "$USER" | tr ' ' '\n' | grep -qx libvirt; then
+    confirm "Add $USER to the libvirt group? (log out / back in afterwards)" \
+      && run sudo usermod -aG libvirt "$USER" || true
+  fi
+  install_plugin vagrant-libvirt
+}
+
+install_plugin() {
+  local plugin=$1
+  command -v vagrant >/dev/null 2>&1 || die "vagrant is not installed; install it first (brew install --cask vagrant | sudo apt-get install vagrant)"
+  if vagrant plugin list 2>/dev/null | grep -q "^$plugin "; then
+    info "$plugin plugin already installed."
+  else
+    confirm "Install vagrant plugin '$plugin'?" || die "aborted"
+    run vagrant plugin install "$plugin"
+  fi
+}
+
+info "Host:     $(host_platform)"
+info "Provider: $provider"
+echo
+
+case "$(host_platform)::$provider" in
+  darwin-arm64::qemu)        install_macos_qemu ;;
+  darwin-arm64::virtualbox)  die "VirtualBox is not officially supported on Apple Silicon. Use qemu (default), or set PROVIDER=parallels / utm." ;;
+  darwin-*::qemu)            install_macos_qemu ;;
+  darwin-*::virtualbox)      install_macos_virtualbox ;;
+  darwin-*::parallels)       ensure_brew; confirm "Install Parallels via brew cask?" && run brew install --cask parallels; install_plugin vagrant-parallels ;;
+  linux-*::virtualbox)       install_linux_virtualbox ;;
+  linux-*::libvirt)          install_linux_libvirt ;;
+  linux-*::qemu)             die "Use libvirt on Linux instead of qemu (libvirt wraps qemu and has full Vagrant support)." ;;
+  *)                         die "no installer recipe for $(host_platform) + $provider — install manually" ;;
+esac
+
+echo
+info "Done. Run 'make doctor' to verify."


### PR DESCRIPTION
## Summary
- `bin/install-provider` detects host platform + provider and installs the right provider package and Vagrant plugin via `brew`, `apt`, or `dnf`.
- New `make setup` target wraps it.
- `make doctor` now points users at `make setup` when a check fails.

## Per-host behavior
| Host                | What `make setup` installs                                           |
|---------------------|----------------------------------------------------------------------|
| macOS Apple Silicon | `qemu` (brew) + `vagrant-qemu` plugin                                |
| macOS Intel         | VirtualBox (brew cask)                                               |
| Linux apt           | libvirt + qemu-kvm + vagrant-libvirt (or VirtualBox if `PROVIDER=`)  |
| Linux dnf/yum       | libvirt + qemu-kvm + vagrant-libvirt                                 |

Each install prompts for `[y/N]`; pass `YES=1` to run unattended. Anything already present is skipped.

## Test plan
- [x] `make help` shows the new target
- [x] On Apple Silicon: `bin/install-provider` correctly skips `qemu` (already installed) and prompts for the `vagrant-qemu` plugin
- [ ] End-to-end: fresh Linux box runs `make setup && make install && make new ... && make up`