### PR TITLE
Stack-rot audit 2026-05-17

### DIFF
--- a/boxes.yaml
+++ b/boxes.yaml
@@ -34,8 +34,12 @@ ubuntu24:
     virtualbox:     bento/ubuntu-24.04
     libvirt:        generic/ubuntu2404
 
-# Ubuntu 26.04 LTS released April 2026; not yet packaged by bento.
-# Re-add once bento/ubuntu-26.04 ships.
+# Ubuntu 26.04 LTS released April 2026; bento box not yet confirmed available.
+# Last audited 2026-05-17: app.vagrantup.com was unreachable from CI (network
+# allowlist); verify manually with:
+#   curl -fsS https://app.vagrantup.com/api/v1/box/bento/ubuntu-26.04 | python3 -c \
+#     "import sys,json; d=json.load(sys.stdin); print([p['name'] for p in d['current_version']['providers']])"
+# Re-add once bento/ubuntu-26.04 ships with vmware_desktop providers.
 # ubuntu26:
 #   family: apt
 #   ansible: apt


### PR DESCRIPTION
## Stack-rot audit — 2026-05-17

Opened as PR (not direct push) because this is an unattended scheduled run; merge or close at your discretion.

---

### Audit results

| Check | Status | Notes |
|---|---|---|
| **Vagrant Cloud API reachability** | ⚠️ blocked | `app.vagrantup.com` returns 403 "Host not in allowlist" from this CI environment. All box checks below are **unverifiable from this runner** — see manual check command added to `boxes.yaml`. |
| bento/ubuntu-22.04 — vmware_desktop arm64+amd64 | ❓ unverifiable | API blocked (see above) |
| bento/ubuntu-24.04 — vmware_desktop arm64+amd64 | ❓ unverifiable | API blocked |
| bento/rockylinux-9 — vmware_desktop arm64+amd64 | ❓ unverifiable | API blocked |
| bento/rockylinux-10.0 — vmware_desktop arm64+amd64 | ❓ unverifiable | API blocked |
| bento/fedora-42 — vmware_desktop arm64+amd64 | ❓ unverifiable | API blocked |
| **bento/ubuntu-26.04** (new box check) | ❓ unverifiable | Ubuntu 26.04 LTS released April 2026; bento packaging status unknown — API blocked. `boxes.yaml` comment updated with manual verification command. Do NOT uncomment the `ubuntu26:` block until confirmed. |
| generic/ubuntu2604 (libvirt counterpart) | ❓ unverifiable | API blocked |
| `apt.releases.hashicorp.com/gpg` | ✅ 200 | GPG key endpoint healthy |
| `rpm.releases.hashicorp.com/gpg` | ✅ 200 | GPG key endpoint healthy |
| `rpm.releases.hashicorp.com/RHEL/hashicorp.repo` | ✅ 200 | Repo file valid; contains correct `gpgkey=` reference |
| `rpm.releases.hashicorp.com/fedora/hashicorp.repo` | ✅ 200 | Repo file valid |
| Vagrant VMware Utility download page | ⚠️ blocked | `developer.hashicorp.com` blocked by network allowlist; URL string `https://developer.hashicorp.com/vagrant/install#vmware-utility` in `bin/install-provider` is intact and correct per last known state |
| Broadcom Fusion download path | ⚠️ blocked | `support.broadcom.com` blocked; URL string present and correct in `bin/install-provider` and `bin/doctor`. Script already notes the Homebrew cask was disabled 2025-06-23 — no change needed. |
| `brew install --cask parallels` | ⚠️ blocked | `formulae.brew.sh` blocked; referenced in `bin/install-provider` line 72 and `bin/doctor` line 55. Historically stable cask — no reason to suspect removal. |
| `brew install --cask vmware-fusion` | ✅ already handled | Script correctly documents cask disabled 2025-06-23 (Broadcom auth required) and directs user to manual Broadcom download. No change needed. |
| `vagrant plugin install vagrant-vmware-desktop` | ✅ static OK | Plugin name unchanged; referenced correctly in both scripts. |
| `vagrant plugin install vagrant-libvirt` | ✅ static OK | Plugin name unchanged; `linux_libvirt` path in `install-provider` uses correct apt/dnf package names (`libvirt-daemon-system`, `libvirt-clients`, `libvirt-dev`, `qemu-kvm`). |
| `vagrant plugin install vagrant-parallels` | ✅ static OK | Plugin name unchanged. |

---

### Changes in this PR

- **`boxes.yaml`** — Updated the `ubuntu26` comment block to add the last-audited date (2026-05-17) and a copy-paste `curl` command so the next auditor can verify `bento/ubuntu-26.04` availability manually without digging through scripts.

### What needs a human eye

1. **Box availability (Vagrant Cloud blocked)** — Run the `curl` command now in `boxes.yaml` from a machine with unrestricted outbound access. If `bento/ubuntu-26.04` exists with `vmware_desktop` providers, uncomment the `ubuntu26:` block and mirror the `ubuntu24:` entry.
2. **`developer.hashicorp.com/vagrant/install`** — Spot-check that the `#vmware-utility` anchor and `.pkg` download still exist and the version referenced in `bin/install-provider` is current.
3. **`formulae.brew.sh/cask/parallels`** — Confirm the Parallels cask is still active and not deprecated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LQ9zsFnEPPVJ3A7yA1CM3w)_